### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cli @snyk/productinfra_cli
+* @snyk/cli @snyk/productinfra_cli @snyk/developer-experience_cli


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change
[!IMPORTANT]:
If this service relies on vervet, you will need to run a command to regenerate the spec (e.g. `make generate`) before merging it.
The best option is to:
- checkout the branch `update-ownership-PRODSEC-10215-creg`
- run the command
- commit and push the results to this PR before you approve and merge it.